### PR TITLE
Fix DOP NW tileindex

### DIFF
--- a/.github/workflows/tindex_dop_nw.yml
+++ b/.github/workflows/tindex_dop_nw.yml
@@ -6,7 +6,7 @@ on:
   #     - dop_nw
   schedule:
     # run tile index creation every month
-    - cron:  '0 16 16 * *'
+    - cron:  '0 9 19 * *'
 
 jobs:
   update-tindex-dop-nw:

--- a/DOP/NW/openNRW_DOP_tindex.py
+++ b/DOP/NW/openNRW_DOP_tindex.py
@@ -78,7 +78,7 @@ for num, dop in enumerate(DOP_list):
             "location": dop
         },
         "geometry": {
-            "type": "Polygon", "coordinates": [[[x1, y1], [x2, y1], [x2, y2], [x1, y2], [x2, y1]]]
+            "type": "Polygon", "coordinates": [[[x1, y1], [x2, y1], [x2, y2], [x1, y2], [x1, y1]]]
         }
     }
     geojson_dict["features"].append(feat)


### PR DESCRIPTION
Fixes `ERROR 1: IllegalArgumentException: Points of LinearRing do not form a closed linestring` in resulting GPKG tile index file.