### PR TITLE
Dockerfile: add python and pip3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM osgeo/grass-gis:current-alpine
 
+# install python and pip3
+RUN apk add python3 py3-pip
+
 # installations for DOP NW tindex
 RUN apk add lynx parallel
 


### PR DESCRIPTION
The Docker build is failing because `pip3` is not available in the Alpine Linux container, leading to

```sh
#9 0.120 /bin/sh: pip3: not found
#9 ERROR: process "/bin/sh -c pip3 install selenium" did not complete successfully: exit code: 127
```

The base image `osgeo/grass-gis:current-alpine` doesn't include Python's pip by default - so we install it first.