### PR TITLE
Update workflows: python installation/venv

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add firefox
 ENV PATH="/opt/venv/bin:$PATH"
 RUN /usr/bin/python3 -m venv --system-site-packages /opt/venv
 
-
 # installations for ALKIS LK HE tindex
 RUN pip3 install requests remotezip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,9 @@ RUN apk add lynx parallel
 RUN apk add firefox
 
 # python3 + pip3
-RUN apk add --no-cache python3 py3-pip
-RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN /usr/bin/python3 -m venv --system-site-packages --without-pip /opt/venv
-RUN python3 -m ensurepip
+RUN /usr/bin/python3 -m venv --system-site-packages /opt/venv
+
 
 # installations for ALKIS LK HE tindex
 RUN pip3 install requests remotezip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,13 @@ RUN apk add lynx parallel
 # install firefox and xsel for DOP SN tindex
 RUN apk add firefox
 
+# python3 + pip3
+RUN apk add --no-cache python3 py3-pip
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN /usr/bin/python3 -m venv --system-site-packages --without-pip /opt/venv
+RUN python3 -m ensurepip
+
 # installations for ALKIS LK HE tindex
 RUN pip3 install requests remotezip
 


### PR DESCRIPTION
To avoid e.g. following error
```
#10 [5/8] RUN pip3 install pandas geopandas shapely fiona
#10 0.500 error: externally-managed-environment
#10 0.500 
#10 0.500 × This environment is externally managed
#10 0.500 ╰─> 
#10 0.500     The system-wide python installation should be maintained using the system
#10 0.500     package manager (apk) only.
#10 0.500     
#10 0.500     If the package in question is not packaged already (and hence installable via
#10 0.500     "apk add py3-somepackage"), please consider installing it inside a virtual
#10 0.500     environment, e.g.:
#10 0.500     
#10 0.500     python3 -m venv /path/to/venv
#10 0.500     . /path/to/venv/bin/activate
#10 0.500     pip install mypackage
#10 0.500     
#10 0.500     To exit the virtual environment, run:
#10 0.500     
#10 0.500     deactivate
#10 0.500     
#10 0.500     The virtual environment is not deleted, and can be re-entered by re-sourcing
#10 0.500     the activate file.
#10 0.500     
#10 0.500     To automatically manage virtual environments, consider using pipx (from the
#10 0.500     pipx package).
#10 0.500 
#10 0.500 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
```